### PR TITLE
sort acl values

### DIFF
--- a/apis/config/v1alpha1/common_types.go
+++ b/apis/config/v1alpha1/common_types.go
@@ -2,6 +2,7 @@ package v1alpha1
 
 import (
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -188,6 +189,7 @@ type ACL struct {
 }
 
 func (a *ACL) Model() (models.ACL, error) {
+	sort.Strings(a.Values)
 	values := strings.Join(a.Values, " ")
 
 	if len(a.Values) > defaults.MaxLineArgs-3 {


### PR DESCRIPTION
sort acl values in common types to have consistency with the acl values files