### PR TITLE
feat: allow adding annotations to instance service

### DIFF
--- a/apis/proxy/v1alpha1/instance_types.go
+++ b/apis/proxy/v1alpha1/instance_types.go
@@ -130,6 +130,10 @@ type ServiceSpec struct {
 	// +kubebuilder:validation:Enum=ClusterIP;NodePort;LoadBalancer
 	// +kubebuilder:default=ClusterIP
 	Type *corev1.ServiceType `json:"type,omitempty"`
+	// Annotations to be added to Service.
+	// +optional
+	// +nullable
+	Annotations map[string]string `json:"annotations,omitempty"`
 }
 
 type Metrics struct {

--- a/controllers/instance/instance_controller_test.go
+++ b/controllers/instance/instance_controller_test.go
@@ -61,6 +61,10 @@ var _ = Describe("Reconcile", Label("controller"), func() {
 				"label-test": "ok",
 			}
 
+			annotations := map[string]string{
+				"service.beta.kubernetes.io/aws-load-balancer-scheme": "internet-facing",
+			}
+
 			dur, _ := time.ParseDuration("30s")
 
 			proxy = &proxyv1alpha1.Instance{
@@ -86,8 +90,9 @@ var _ = Describe("Reconcile", Label("controller"), func() {
 					Env:    labels,
 					Network: proxyv1alpha1.Network{
 						Service: proxyv1alpha1.ServiceSpec{
-							Enabled: true,
-							Type:    ptr.To(corev1.ServiceTypeLoadBalancer),
+							Enabled:     true,
+							Type:        ptr.To(corev1.ServiceTypeLoadBalancer),
+							Annotations: annotations,
 						},
 					},
 				},
@@ -420,6 +425,7 @@ var _ = Describe("Reconcile", Label("controller"), func() {
 			service := &corev1.Service{}
 			Ω(cli.Get(ctx, client.ObjectKey{Namespace: proxy.Namespace, Name: utils.GetServiceName(proxy)}, service)).ShouldNot(HaveOccurred())
 			Ω(service.Spec.Type).Should(Equal(corev1.ServiceTypeLoadBalancer))
+			Ω(service.Annotations["service.beta.kubernetes.io/aws-load-balancer-scheme"]).Should(Equal("internet-facing"))
 
 			secret := &corev1.Secret{}
 			Ω(cli.Get(ctx, client.ObjectKey{Namespace: proxy.Namespace, Name: "bar-foo-haproxy-config"}, secret)).ShouldNot(HaveOccurred())

--- a/controllers/instance/service.go
+++ b/controllers/instance/service.go
@@ -37,6 +37,10 @@ func (r *Reconciler) reconcileService(ctx context.Context, instance *proxyv1alph
 
 		service.Labels = utils.GetAppSelectorLabels(instance)
 
+		if instance.Spec.Network.Service.Annotations != nil {
+			service.Annotations = instance.Spec.Network.Service.Annotations
+		}
+
 		if len(instance.Spec.Network.HostIPs) == 0 {
 			service.Spec.Selector = utils.GetAppSelectorLabels(instance)
 		}

--- a/helm/haproxy-operator/crds/proxy.haproxy.com_instances.yaml
+++ b/helm/haproxy-operator/crds/proxy.haproxy.com_instances.yaml
@@ -955,6 +955,12 @@ spec:
                   service:
                     description: Service defines the desired state for a Service.
                     properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: Annotations to be added to Service.
+                        nullable: true
+                        type: object
                       enabled:
                         description: Enabled will toggle the creation of a Service.
                         type: boolean


### PR DESCRIPTION
With this change, Load Balancer controllers such as the one from AWS should work as expected.

Related to: https://github.com/six-group/haproxy-operator/issues/36#issuecomment-1960518759