### PR TITLE
fix(instance): reconcile Service.spec.type in mutate block

### DIFF
--- a/controllers/instance/service.go
+++ b/controllers/instance/service.go
@@ -26,13 +26,13 @@ func (r *Reconciler) reconcileService(ctx context.Context, instance *proxyv1alph
 		},
 	}
 
-	if serviceType := instance.Spec.Network.Service.Type; serviceType != nil {
-		service.Spec.Type = *serviceType
-	}
-
 	result, err := controllerutil.CreateOrUpdate(ctx, r.Client, service, func() error {
 		if err := controllerutil.SetOwnerReference(instance, service, r.Scheme); err != nil {
 			return err
+		}
+
+		if serviceType := instance.Spec.Network.Service.Type; serviceType != nil {
+			service.Spec.Type = *serviceType
 		}
 
 		service.Labels = utils.GetAppSelectorLabels(instance)


### PR DESCRIPTION
**Summary**  
Updates the Instance controller so `Service.spec.type` is consistently reconciled for update operations.

**Problem**  
Changing an `Instance` with `network.service.type: LoadBalancer` did not switch an existing Service from `ClusterIP` to `LoadBalancer`. 

**Root Cause**  
`Service.spec.type` was assigned outside the `controllerutil.CreateOrUpdate` mutate function. During updates, the fetched live object overwrote that assignment, while fields set inside the mutate function (e.g., annotations) were applied as expected.

**Solution**  
Move the assignment of `Service.spec.type` into the mutate function so the desired type is part of the reconciled state. This makes the behavior deterministic on both create and update. No breaking changes.

**Changelog**  
Fix: `Instance.network.service.type` is now honored during updates (e.g., `ClusterIP` → `LoadBalancer`).