### PR TITLE
Add h1-case-adjust-bogus-server option

### DIFF
--- a/apis/proxy/v1alpha1/instance_types.go
+++ b/apis/proxy/v1alpha1/instance_types.go
@@ -658,6 +658,9 @@ type DefaultsConfiguration struct {
 	// Logging is used to configure default logging for all proxies.
 	// +optional
 	Logging *DefaultsLoggingConfiguration `json:"logging,omitempty"`
+	// H1CaseAdjustBogusServer enables h1-case-adjust-bogus-server in the defaults section.
+	// +optional
+	H1CaseAdjustBogusServer bool `json:"h1CaseAdjustBogusServer,omitempty"`
 	// AdditionalParameters can be used to specify any further configuration statements which are not covered in this section explicitly.
 	// +optional
 	AdditionalParameters string `json:"additionalParameters,omitempty"`
@@ -719,6 +722,10 @@ func (d *DefaultsConfiguration) Model() (models.Defaults, error) {
 	if d.Logging != nil {
 		defaults.Httplog = ptr.Deref(d.Logging.HTTPLog, false)
 		defaults.Tcplog = ptr.Deref(d.Logging.TCPLog, false)
+	}
+
+	if d.H1CaseAdjustBogusServer {
+		defaults.H1CaseAdjustBogusServer = models.DefaultsBaseH1CaseAdjustBogusServerEnabled
 	}
 
 	return defaults, defaults.Validate(strfmt.Default)

--- a/apis/proxy/v1alpha1/instance_types_test.go
+++ b/apis/proxy/v1alpha1/instance_types_test.go
@@ -1,0 +1,53 @@
+package v1alpha1_test
+
+import (
+	"strings"
+	"testing"
+
+	parser "github.com/haproxytech/client-native/v6/config-parser"
+	proxyv1alpha1 "github.com/six-group/haproxy-operator/apis/proxy/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestDefaultsConfiguration_AddToParser_H1CaseAdjustBogusServerEnabled(t *testing.T) {
+	p, err := parser.New()
+	if err != nil {
+		t.Fatalf("failed to create parser: %v", err)
+	}
+
+	d := &proxyv1alpha1.DefaultsConfiguration{
+		Mode:                    "http",
+		Timeouts:                map[string]metav1.Duration{},
+		H1CaseAdjustBogusServer: true,
+	}
+
+	if err := d.AddToParser(p); err != nil {
+		t.Fatalf("failed to add defaults to parser: %v", err)
+	}
+
+	cfg := p.String()
+	if !strings.Contains(cfg, "option h1-case-adjust-bogus-server") {
+		t.Fatalf("expected h1-case-adjust-bogus-server option in defaults section, got:\n%s", cfg)
+	}
+}
+
+func TestDefaultsConfiguration_AddToParser_H1CaseAdjustBogusServerDisabledByDefault(t *testing.T) {
+	p, err := parser.New()
+	if err != nil {
+		t.Fatalf("failed to create parser: %v", err)
+	}
+
+	d := &proxyv1alpha1.DefaultsConfiguration{
+		Mode:     "http",
+		Timeouts: map[string]metav1.Duration{},
+	}
+
+	if err := d.AddToParser(p); err != nil {
+		t.Fatalf("failed to add defaults to parser: %v", err)
+	}
+
+	cfg := p.String()
+	if strings.Contains(cfg, "option h1-case-adjust-bogus-server") {
+		t.Fatalf("did not expect h1-case-adjust-bogus-server option in defaults section, got:\n%s", cfg)
+	}
+}

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1258,6 +1258,7 @@ _Appears in:_
 | `errorFiles` _[ErrorFile](#errorfile) array_ | ErrorFiles custom error files to be used |  | Optional: \{\} <br /> |
 | `timeouts` _object (keys:string, values:[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#duration-v1-meta))_ | Timeouts: check, client, client-fin, connect, http-keep-alive, http-request, queue, server, server-fin, tunnel.<br />The timeout value specified in milliseconds by default, but can be in any other unit if the number is suffixed by the unit.<br />More info: https://cbonte.github.io/haproxy-dconv/2.6/configuration.html | \{ client:5s connect:5s server:10s \} |  |
 | `logging` _[DefaultsLoggingConfiguration](#defaultsloggingconfiguration)_ | Logging is used to configure default logging for all proxies. |  | Optional: \{\} <br /> |
+| `h1CaseAdjustBogusServer` _boolean_ | H1CaseAdjustBogusServer enables h1-case-adjust-bogus-server in the defaults section. |  | Optional: \{\} <br /> |
 | `additionalParameters` _string_ | AdditionalParameters can be used to specify any further configuration statements which are not covered in this section explicitly. |  | Optional: \{\} <br /> |
 
 

--- a/helm/haproxy-operator/crds/proxy.haproxy.com_instances.yaml
+++ b/helm/haproxy-operator/crds/proxy.haproxy.com_instances.yaml
@@ -147,6 +147,10 @@ spec:
                         required:
                         - enabled
                         type: object
+                      h1CaseAdjustBogusServer:
+                        description: H1CaseAdjustBogusServer enables h1-case-adjust-bogus-server
+                          in the defaults section.
+                        type: boolean
                       mode:
                         default: http
                         description: Mode can be either 'tcp' or 'http'. In tcp mode


### PR DESCRIPTION
### Summary
This PR adds support for the `option h1-case-adjust-bogus-server` directive in the `defaults` section of the HAProxy configuration.

### Motivation
Currently, there is no way to configure `h1-case-adjust-bogus-server` in the defaults section through the HAProxy Operator CRDs. This option is necessary for environments dealing with legacy or non-compliant backend servers that require strict HTTP/1.1 header casing (e.g., expecting `Content-Type` instead of `content-type`). By adding this boolean field, users can now easily enable this feature globally via the `DefaultsConfiguration`.

### Changes
- Added the `H1CaseAdjustBogusServer` boolean field to the `DefaultsConfiguration` struct in `apis/proxy/v1alpha1/instance_types.go`.
- Updated the `Model()` method for the defaults configuration to map this new field to the native HAProxy model (`models.DefaultsBaseH1CaseAdjustBogusServerEnabled`).
- Added unit tests in `apis/proxy/v1alpha1/instance_types_test.go` to verify the correct generation of the `option h1-case-adjust-bogus-server` directive when enabled, and its absence when disabled.
- Regenerated CRDs and API documentation to reflect the schema updates.

### Checklist
- [x] Code changes implemented
- [x] Unit tests added/updated
- [x] Generated CRDs and API docs updated